### PR TITLE
Choose default source if no input is specified

### DIFF
--- a/mic-volume/mic-volume.sh
+++ b/mic-volume/mic-volume.sh
@@ -2,14 +2,14 @@
 
 if [ -z "$1" ]
 then
-  echo "No Input Provided"
+  volume=$(pacmd list-sources | grep "\* index:" -A 7 | grep "volume" | awk -F/ '{print $2}')
 else
   volume=$(pacmd list-sources | grep "$1" -A 6 | grep "volume" | awk -F/ '{print $2}')
+fi
 
-  if [ -z "$volume" ]
-  then
-    echo "No Mic Found"
-  else
-    echo "$volume"
-  fi
+if [ -z "$volume" ]
+then
+  echo "No Mic Found"
+else
+  echo "$volume"
 fi


### PR DESCRIPTION
Hi, thanks for the script!

A small addition that I found useful: If  `MICROPHONE_NAME` is not specified, the script automatically chooses the default one. (This is indicated by `*` before the index)